### PR TITLE
VPC SC request REQ-0a98e501 for test-perim-a

### DIFF
--- a/accesslevel.tf
+++ b/accesslevel.tf
@@ -1,1 +1,8 @@
+module "vpc-service-controls-access-level_req-0a98e501-rule1" {
+  source  = "tfe.<domain>/<namespace>/vpc-service-controls/google//modules/access_level"
+  version = "0.0.4"
+  policy  = var.policy
+  name    = "req-0a98e501-rule1"
+  ip_subnetworks = ["192.168.1.1/32"]
+}
 

--- a/terraform.auto.tfvars
+++ b/terraform.auto.tfvars
@@ -1,2 +1,22 @@
-ingress_policies = []
+ingress_policies = [
+  {
+    from = {
+      identity_type = ""
+      sources = {
+        resources = []
+        access_levels = ["req-0a98e501-rule1"]
+      }
+      identities = ["serviceAccount:my-app-service-account@netsec-d.iam.gserviceaccount.com"]
+    }
+    to = {
+      resources = ["projects/92738475"]
+      operations = {
+        "bigquery.googleapis.com" = {
+          methods = ["BigQueryWrite.AppendRows"]
+          permissions = []
+        }
+      }
+    }
+  },
+]
 egress_policies  = []


### PR DESCRIPTION
This pull request applies the VPC Service Controls request `REQ-0a98e501` to perimeter `test-perim-a`.